### PR TITLE
Fixed a bug causing loss of nanosecond precision when time is not given

### DIFF
--- a/senml.go
+++ b/senml.go
@@ -313,9 +313,8 @@ func Normalize(senml SenML) SenML {
 
 		if r.Time <= 0 {
 			// convert to absolute time
-			var now int64 = time.Now().UnixNano()
-			var t int64 = now / 1000000000.0
-			r.Time = float64(t) + r.Time
+			var now float64 = float64(time.Now().UnixNano()) / 1000000000
+			r.Time = now + r.Time
 		}
 
 		if (r.Value != nil) || (len(r.StringValue) > 0) || (len(r.DataValue) > 0) || (r.BoolValue != nil) {

--- a/senml_test.go
+++ b/senml_test.go
@@ -3,9 +3,10 @@ package senml_test
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/cisco/senml"
 	"strconv"
 	"testing"
+
+	"github.com/cisco/senml"
 )
 
 func ExampleEncode1() {
@@ -54,7 +55,7 @@ type TestVector struct {
 var testVectors = []TestVector{
 	{true, senml.JSON, false, "W3siYm4iOiJkZXYxMjMiLCJidCI6LTQ1LjY3LCJidSI6ImRlZ0MiLCJidmVyIjo1LCJuIjoidGVtcCIsInUiOiJkZWdDIiwidCI6LTEsInV0IjoxMCwidiI6MjIuMSwicyI6MH0seyJuIjoicm9vbSIsInQiOi0xLCJ2cyI6ImtpdGNoZW4ifSx7Im4iOiJkYXRhIiwidmQiOiJhYmMifSx7Im4iOiJvayIsInZiIjp0cnVlfV0="},
 	{true, senml.CBOR, true, "hKpiYm5mZGV2MTIzYmJ0+8BG1cKPXCj2YmJ1ZGRlZ0NkYnZlcgVhbmR0ZW1wYXP7AAAAAAAAAABhdPu/8AAAAAAAAGF1ZGRlZ0NidXT7QCQAAAAAAABhdvtANhmZmZmZmqNhbmRyb29tYXT7v/AAAAAAAABidnNna2l0Y2hlbqJhbmRkYXRhYnZkY2FiY6JhbmJva2J2YvU="},
-	{true, senml.XML, false, "PHNlbnNtbCB4bWxucz0idXJuOmlldGY6cGFyYW1zOnhtbDpuczpzZW5tbCI+PHNlbm1sIGJuPSJkZXYxMjMiIGJ0PSItNDUuNjciIGJ1PSJkZWdDIiBidmVyPSI1IiBuPSJ0ZW1wIiB1PSJkZWdDIiB0PSItMSIgdXQ9IjEwIiB2PSIyMi4xIiBzdW09IjAiPjwvc2VubWw+PHNlbm1sIG49InJvb20iIHQ9Ii0xIiB2cz0ia2l0Y2hlbiI+PC9zZW5tbD48c2VubWwgbj0iZGF0YSIgdmQ9ImFiYyI+PC9zZW5tbD48c2VubWwgbj0ib2siIHZiPSJ0cnVlIj48L3Nlbm1sPjwvc2Vuc21sPg=="},
+	{true, senml.XML, false, "PHNlbnNtbCB4bWxucz0idXJuOmlldGY6cGFyYW1zOnhtbDpuczpzZW5tbCI+PHNlbm1sIGJuPSJkZXYxMjMiIGJ0PSItNDUuNjciIGJ1PSJkZWdDIiBidmVyPSI1IiBuPSJ0ZW1wIiB1PSJkZWdDIiB0PSItMSIgdXQ9IjEwIiB2PSIyMi4xIiBzPSIwIj48L3Nlbm1sPjxzZW5tbCBuPSJyb29tIiB0PSItMSIgdnM9ImtpdGNoZW4iPjwvc2VubWw+PHNlbm1sIG49ImRhdGEiIHZkPSJhYmMiPjwvc2VubWw+PHNlbm1sIG49Im9rIiB2Yj0idHJ1ZSI+PC9zZW5tbD48L3NlbnNtbD4="},
 	{false, senml.CSV, false, "dGVtcCwyNTU2OC45OTk5ODgsMjIuMTAwMDAwLGRlZ0MNCg=="},
 	{true, senml.MPACK, true, "lIqiYm6mZGV2MTIzomJ0y8BG1cKPXCj2omJ1pGRlZ0OkYnZlcgWhbqR0ZW1woXPLAAAAAAAAAAChdMu/8AAAAAAAAKF1pGRlZ0OidXTLQCQAAAAAAAChdstANhmZmZmZmoOhbqRyb29toXTLv/AAAAAAAACidnOna2l0Y2hlboKhbqRkYXRhonZko2FiY4KhbqJva6J2YsM="},
 	{false, senml.LINEP, false, "Zmx1ZmZ5U2VubWwsbj10ZW1wLHU9ZGVnQyB2PTIyLjEgLTEwMDAwMDAwMDAK"},
@@ -91,7 +92,12 @@ func TestEncode(t *testing.T) {
 		}
 
 		if base64.StdEncoding.EncodeToString(dataOut) != vector.value {
-			t.Error("Failed Encode for format " + strconv.Itoa(i) + " got: " + base64.StdEncoding.EncodeToString(dataOut))
+			t.Errorf("Failed Encode for format %d. Got:\n%s", i, string(dataOut))
+			decoded, err := base64.StdEncoding.DecodeString(vector.value)
+			if err != nil {
+				t.Fatalf("Error decoding test value: %s", err)
+			}
+			t.Errorf("Expected:\n%s", string(decoded))
 		}
 	}
 
@@ -147,8 +153,14 @@ func TestNormalize(t *testing.T) {
 	}
 	fmt.Println("Test Normalize got: " + string(dataOut))
 
-	if base64.StdEncoding.EncodeToString(dataOut) != "WwogIHsiYnZlciI6NSwibiI6ImRldjEyMy90ZW1wIiwidSI6ImRlZ0MiLCJ0Ijo4OTc4NDQuNjcsInV0IjoxMCwidiI6MjIuMSwicyI6MH0sCiAgeyJidmVyIjo1LCJuIjoiZGV2MTIzL3Jvb20iLCJ1IjoiZGVnQyIsInQiOjg5Nzg0NC42NywidnMiOiJraXRjaGVuIn0sCiAgeyJidmVyIjo1LCJuIjoiZGV2MTIzL29rIiwidSI6ImRlZ0MiLCJ0Ijo4OTc4NDUuNjcsInZiIjp0cnVlfQpdCg==" {
-		t.Error("Failed Normalize got: " + base64.StdEncoding.EncodeToString(dataOut))
+	testValue := "WwogIHsiYnZlciI6NSwibiI6ImRldjEyMy90ZW1wIiwidSI6ImRlZ0MiLCJ0Ijo4OTc4NDQuNjcsInV0IjoxMCwidiI6MjIuMSwicyI6MH0sCiAgeyJidmVyIjo1LCJuIjoiZGV2MTIzL3Jvb20iLCJ1IjoiZGVnQyIsInQiOjg5Nzg0NC42NywidnMiOiJraXRjaGVuIn0sCiAgeyJidmVyIjo1LCJuIjoiZGV2MTIzL2RhdGEiLCJ1IjoiZGVnQyIsInQiOjg5Nzg0NS42NywidmQiOiJhYmMifSwKICB7ImJ2ZXIiOjUsIm4iOiJkZXYxMjMvb2siLCJ1IjoiZGVnQyIsInQiOjg5Nzg0NS42NywidmIiOnRydWV9Cl0K"
+	if base64.StdEncoding.EncodeToString(dataOut) != testValue {
+		t.Errorf("Failed Normalize got:\n%v", string(dataOut))
+		decoded, err := base64.StdEncoding.DecodeString(testValue)
+		if err != nil {
+			t.Fatalf("Error decoding test value: %s", err)
+		}
+		t.Errorf("Expected:\n%v", string(decoded))
 	}
 }
 


### PR DESCRIPTION
Hi,

The Normalize function was converting nanoseconds (int64) into seconds (int64) and then casting to float64, losing all the floating points. The proposed changes fixes it.

Please merge :)